### PR TITLE
Implement favorites

### DIFF
--- a/src/api/favorites/favorites.controller.js
+++ b/src/api/favorites/favorites.controller.js
@@ -1,0 +1,65 @@
+import * as favoritesService from './favorites.service.js';
+
+export async function getFavoriteServices(req, res) {
+  try {
+    const result = await favoritesService.getFavoriteServices(req.user.userId);
+    res.json(result);
+  } catch (error) {
+    console.error('🔥 Get Favorite Services error:', error);
+    res.status(500).json({ error: 'Failed to fetch favorite services' });
+  }
+}
+
+export async function addFavoriteService(req, res) {
+  try {
+    const serviceId = parseInt(req.params.id);
+    const result = await favoritesService.addFavoriteService(req.user.userId, serviceId);
+    res.json(result);
+  } catch (error) {
+    console.error('🔥 Add Favorite Service error:', error);
+    res.status(500).json({ error: 'Failed to add favorite service' });
+  }
+}
+
+export async function removeFavoriteService(req, res) {
+  try {
+    const serviceId = parseInt(req.params.id);
+    await favoritesService.removeFavoriteService(req.user.userId, serviceId);
+    res.json({ message: 'Removed from favorites' });
+  } catch (error) {
+    console.error('🔥 Remove Favorite Service error:', error);
+    res.status(500).json({ error: 'Failed to remove favorite service' });
+  }
+}
+
+export async function getFavoriteJobs(req, res) {
+  try {
+    const result = await favoritesService.getFavoriteJobs(req.user.userId);
+    res.json(result);
+  } catch (error) {
+    console.error('🔥 Get Favorite Jobs error:', error);
+    res.status(500).json({ error: 'Failed to fetch favorite jobs' });
+  }
+}
+
+export async function addFavoriteJob(req, res) {
+  try {
+    const jobId = parseInt(req.params.id);
+    const result = await favoritesService.addFavoriteJob(req.user.userId, jobId);
+    res.json(result);
+  } catch (error) {
+    console.error('🔥 Add Favorite Job error:', error);
+    res.status(500).json({ error: 'Failed to add favorite job' });
+  }
+}
+
+export async function removeFavoriteJob(req, res) {
+  try {
+    const jobId = parseInt(req.params.id);
+    await favoritesService.removeFavoriteJob(req.user.userId, jobId);
+    res.json({ message: 'Removed from favorites' });
+  } catch (error) {
+    console.error('🔥 Remove Favorite Job error:', error);
+    res.status(500).json({ error: 'Failed to remove favorite job' });
+  }
+}

--- a/src/api/favorites/favorites.routes.js
+++ b/src/api/favorites/favorites.routes.js
@@ -1,0 +1,15 @@
+import { Router } from 'express';
+import * as favoritesController from './favorites.controller.js';
+import { authMiddleware } from '../../middleware/authMiddleware.js';
+
+const router = Router();
+
+router.get('/services', authMiddleware, favoritesController.getFavoriteServices);
+router.post('/services/:id', authMiddleware, favoritesController.addFavoriteService);
+router.delete('/services/:id', authMiddleware, favoritesController.removeFavoriteService);
+
+router.get('/jobs', authMiddleware, favoritesController.getFavoriteJobs);
+router.post('/jobs/:id', authMiddleware, favoritesController.addFavoriteJob);
+router.delete('/jobs/:id', authMiddleware, favoritesController.removeFavoriteJob);
+
+export default router;

--- a/src/api/favorites/favorites.service.js
+++ b/src/api/favorites/favorites.service.js
@@ -1,0 +1,66 @@
+import { PrismaClient } from '@prisma/client';
+const prisma = new PrismaClient();
+
+export async function addFavoriteService(userId, serviceId) {
+  await prisma.favoriteService.upsert({
+    where: { userId_serviceId: { userId, serviceId } },
+    update: {},
+    create: { userId, serviceId }
+  });
+  return { message: 'Added to favorites' };
+}
+
+export async function removeFavoriteService(userId, serviceId) {
+  await prisma.favoriteService.deleteMany({ where: { userId, serviceId } });
+}
+
+export async function getFavoriteServices(userId) {
+  const favorites = await prisma.favoriteService.findMany({
+    where: { userId },
+    include: { service: { include: { user: { select: { fullName: true } } } } },
+    orderBy: { createdAt: 'desc' }
+  });
+  return JSON.parse(
+    JSON.stringify(
+      favorites.map(f => ({
+        id: f.service.id,
+        title: f.service.title,
+        price: f.service.price,
+        image: Array.isArray(f.service.images) && f.service.images.length > 0 ? f.service.images[0] : null,
+        author: f.service.user?.fullName || ''
+      })),
+      (k, v) => typeof v === 'bigint' ? v.toString() : v
+    )
+  );
+}
+
+export async function addFavoriteJob(userId, jobId) {
+  await prisma.favoriteJob.upsert({
+    where: { userId_jobId: { userId, jobId } },
+    update: {},
+    create: { userId, jobId }
+  });
+  return { message: 'Added to favorites' };
+}
+
+export async function removeFavoriteJob(userId, jobId) {
+  await prisma.favoriteJob.deleteMany({ where: { userId, jobId } });
+}
+
+export async function getFavoriteJobs(userId) {
+  const favorites = await prisma.favoriteJob.findMany({
+    where: { userId },
+    include: { job: { include: { user: { select: { fullName: true } } } } },
+    orderBy: { createdAt: 'desc' }
+  });
+  return favorites.map(f => ({
+    id: f.job.id,
+    title: f.job.title,
+    price: f.job.price,
+    image: f.job.images.length > 0 ? f.job.images[0] : null,
+    author: f.job.user.fullName ?? 'Аноним',
+    regionId: f.job.regionId,
+    cityId: f.job.cityId,
+    address: f.job.address || 'Не указано'
+  }));
+}

--- a/src/core/prisma/schema.prisma
+++ b/src/core/prisma/schema.prisma
@@ -316,3 +316,26 @@ model Notification {
   userId String
   user   User   @relation(fields: [userId], references: [id])
 }
+model FavoriteService {
+  id        BigInt   @id @default(autoincrement())
+  userId    String
+  serviceId BigInt
+  createdAt DateTime @default(now())
+
+  user    User    @relation(fields: [userId], references: [id])
+  service Service @relation(fields: [serviceId], references: [id])
+
+  @@unique([userId, serviceId])
+}
+
+model FavoriteJob {
+  id        BigInt   @id @default(autoincrement())
+  userId    String
+  jobId     BigInt
+  createdAt DateTime @default(now())
+
+  user User @relation(fields: [userId], references: [id])
+  job  Job  @relation(fields: [jobId], references: [id])
+
+  @@unique([userId, jobId])
+}

--- a/src/docs/modules/favorites.yaml
+++ b/src/docs/modules/favorites.yaml
@@ -1,0 +1,81 @@
+/favorites/services:
+  get:
+    tags:
+      - favorites
+    summary: Получить избранные услуги
+    security:
+      - bearerAuth: []
+    responses:
+      '200':
+        description: Список избранных услуг
+  post:
+    tags:
+      - favorites
+    summary: Добавить услугу в избранное
+    security:
+      - bearerAuth: []
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+    responses:
+      '200':
+        description: Услуга добавлена в избранное
+  delete:
+    tags:
+      - favorites
+    summary: Удалить услугу из избранного
+    security:
+      - bearerAuth: []
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+    responses:
+      '200':
+        description: Услуга удалена из избранного
+
+/favorites/jobs:
+  get:
+    tags:
+      - favorites
+    summary: Получить избранные задания
+    security:
+      - bearerAuth: []
+    responses:
+      '200':
+        description: Список избранных заданий
+  post:
+    tags:
+      - favorites
+    summary: Добавить задание в избранное
+    security:
+      - bearerAuth: []
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+    responses:
+      '200':
+        description: Задание добавлено в избранное
+  delete:
+    tags:
+      - favorites
+    summary: Удалить задание из избранного
+    security:
+      - bearerAuth: []
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+    responses:
+      '200':
+        description: Задание удалено из избранного


### PR DESCRIPTION
## Summary
- add API module for managing favorites
- support new favorites routes for services and jobs
- extend prisma schema with FavoriteService and FavoriteJob models
- document favorites API in OpenAPI modules

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build:openapi` *(fails: Cannot find package 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_683dedcc495c8324b89173fc7f0872cb