### PR TITLE
Add pagination to services list

### DIFF
--- a/src/docs/modules/services.yaml
+++ b/src/docs/modules/services.yaml
@@ -81,6 +81,16 @@
         in: query
         schema:
           type: number
+      - name: page
+        in: query
+        schema:
+          type: integer
+          default: 1
+      - name: limit
+        in: query
+        schema:
+          type: integer
+          default: 20
     responses:
       '200':
         description: Список услуг получен

--- a/src/docs/openapi.yaml
+++ b/src/docs/openapi.yaml
@@ -883,6 +883,16 @@ paths:
           in: query
           schema:
             type: number
+        - name: page
+          in: query
+          schema:
+            type: integer
+            default: 1
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            default: 20
       responses:
         "200":
           description: Список услуг получен


### PR DESCRIPTION
## Summary
- add `page` and `limit` parameters to `getServices`
- update services module docs
- rebuild OpenAPI spec with pagination

## Testing
- `npm run build:openapi` *(fails: Cannot find package 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_683e8ccba0fc8324ba0abdda6c9dcd54