### PR TITLE
Handle BigInt serialization across services

### DIFF
--- a/src/api/auth/auth.service.js
+++ b/src/api/auth/auth.service.js
@@ -1,5 +1,6 @@
 import { PrismaClient } from '@prisma/client';
 const prisma = new PrismaClient();
+import { serialize } from '../../utils/serialize.js';
 import bcrypt from 'bcryptjs';
 import jwt from 'jsonwebtoken';
 import { fixedOtpProvider } from '../../core/otp/index.js';
@@ -17,7 +18,7 @@ export async function register(phone, password) {
   });
 
   await fixedOtpProvider.sendOtp(phone);
-  return { message: 'User registered successfully. OTP sent.', user };
+  return serialize({ message: 'User registered successfully. OTP sent.', user });
 }
 
 export async function verifyOtp(phone, otp) {
@@ -35,11 +36,11 @@ export async function verifyOtp(phone, otp) {
     process.env.JWT_SECRET || 'SECRET_KEY', // Использовать нормальный секрет на проде
     { expiresIn: '7d' }
   )
-  return { 
+  return serialize({
     message: 'Phone number verified successfully',
     token,
     user,
-  };
+  });
 }
 
 export async function login(phone, password) {
@@ -57,7 +58,7 @@ export async function login(phone, password) {
     process.env.JWT_SECRET || 'SECRET_KEY', // Использовать нормальный секрет на проде
     { expiresIn: '7d' }
   );
-  return { token, user };
+  return serialize({ token, user });
 }
 
 export async function attachGoogle(userId, firebaseGoogleId) {
@@ -70,7 +71,7 @@ export async function attachGoogle(userId, firebaseGoogleId) {
     data: { googleId: firebaseGoogleId }
   });
 
-  return { message: 'Google account attached successfully' };
+  return serialize({ message: 'Google account attached successfully' });
 }
 
 export async function requestResetPassword(phone) {
@@ -79,7 +80,7 @@ export async function requestResetPassword(phone) {
   if (!user) throw new Error('User not found');
 
   await fixedOtpProvider.sendOtp(phone);
-  return { message: 'OTP sent to phone' };
+  return serialize({ message: 'OTP sent to phone' });
 }
 
 export async function verifyResetOtp(phone, otp) {
@@ -95,7 +96,7 @@ export async function verifyResetOtp(phone, otp) {
     process.env.JWT_SECRET,
     { expiresIn: '10m' }
   );
-  return { message: 'OTP verified successfully', otpToken };
+  return serialize({ message: 'OTP verified successfully', otpToken });
 }
 
 export async function resetPassword(payload, newPassword) {
@@ -116,11 +117,11 @@ export async function resetPassword(payload, newPassword) {
     process.env.JWT_SECRET || 'SECRET_KEY', // Использовать нормальный секрет на проде
     { expiresIn: '7d' }
   )
-  return { 
+  return serialize({
     message: 'Password reset successfully',
     token,
     user
-  };
+  });
 }
 
 export async function adminLogin(email, password) {
@@ -137,5 +138,5 @@ export async function adminLogin(email, password) {
     { expiresIn: '7d' }
   );
 
-  return { token, admin: { id: admin.id, email: admin.email } };
+  return serialize({ token, admin: { id: admin.id, email: admin.email } });
 }

--- a/src/api/categories/categories.service.js
+++ b/src/api/categories/categories.service.js
@@ -1,8 +1,9 @@
 import { PrismaClient } from '@prisma/client';
 const prisma = new PrismaClient();
+import { serialize } from '../../utils/serialize.js';
 
 export async function getAllCategories(language = 'ru') {
-  return await prisma.category.findMany({
+  const categories = await prisma.category.findMany({
     select: {
       id: true,
       CategoryTranslation: {
@@ -11,10 +12,11 @@ export async function getAllCategories(language = 'ru') {
       }
     }
   });
+  return serialize(categories);
 }
 
 export async function createCategory({ translations }) {
-  return await prisma.category.create({
+  const category = await prisma.category.create({
     data: {
       CategoryTranslation: {
         create: translations.map(t => ({
@@ -24,12 +26,13 @@ export async function createCategory({ translations }) {
       }
     }
   });
+  return serialize(category);
 }
 
 export async function updateCategory(id, { translations }) {
   await prisma.categoryTranslation.deleteMany({ where: { categoryId: id } });
 
-  return await prisma.category.update({
+  const updated = await prisma.category.update({
     where: { id },
     data: {
       CategoryTranslation: {
@@ -40,6 +43,7 @@ export async function updateCategory(id, { translations }) {
       }
     }
   });
+  return serialize(updated);
 }
 
 export async function deleteCategory(id) {

--- a/src/api/chat/chat.service.js
+++ b/src/api/chat/chat.service.js
@@ -1,5 +1,6 @@
 import admin from '../../core/firebase.js';
 import { PrismaClient } from '@prisma/client';
+import { serialize } from '../../utils/serialize.js';
 const prisma = new PrismaClient();
 
 export async function startChat(userId, targetUserId) {
@@ -25,7 +26,7 @@ export async function startChat(userId, targetUserId) {
     });
   }
 
-  return chat;
+  return serialize(chat);
 }
 
 export async function getMyChats(userId) {
@@ -49,7 +50,7 @@ export async function getMyChats(userId) {
     }
   });
 
-  return chats;
+  return serialize(chats);
 }
 
 export async function getChatMessages(userId, chatId) {
@@ -70,7 +71,7 @@ export async function getChatMessages(userId, chatId) {
     orderBy: { createdAt: 'asc' }
   });
 
-  return messages;
+  return serialize(messages);
 }
 
 export async function sendMessage(userId, chatId, content) {
@@ -110,5 +111,5 @@ export async function sendMessage(userId, chatId, content) {
     });
   }
 
-  return message;
+  return serialize(message);
 }

--- a/src/api/favorites/favorites.service.js
+++ b/src/api/favorites/favorites.service.js
@@ -1,5 +1,6 @@
 import { PrismaClient } from '@prisma/client';
 const prisma = new PrismaClient();
+import { serialize } from '../../utils/serialize.js';
 
 export async function addFavoriteService(userId, serviceId) {
   await prisma.favoriteService.upsert({
@@ -25,7 +26,7 @@ export async function getFavoriteServices(userId) {
     include: { user: { select: { fullName: true } } }
   });
   const serviceMap = new Map(services.map(s => [s.id.toString(), s]));
-  return favorites.map(f => {
+  const result = favorites.map(f => {
     const service = serviceMap.get(f.serviceId.toString());
     return service
       ? {
@@ -37,6 +38,7 @@ export async function getFavoriteServices(userId) {
         }
       : null;
   }).filter(Boolean);
+  return serialize(result);
 }
 
 export async function addFavoriteJob(userId, jobId) {
@@ -63,7 +65,7 @@ export async function getFavoriteJobs(userId) {
     include: { user: { select: { fullName: true } } }
   });
   const jobMap = new Map(jobs.map(j => [j.id.toString(), j]));
-  return favorites.map(f => {
+  const resultJobs = favorites.map(f => {
     const job = jobMap.get(f.jobId.toString());
     return job
       ? {
@@ -78,4 +80,5 @@ export async function getFavoriteJobs(userId) {
         }
       : null;
   }).filter(Boolean);
+  return serialize(resultJobs);
 }

--- a/src/api/location/location.service.js
+++ b/src/api/location/location.service.js
@@ -1,8 +1,9 @@
 import { PrismaClient } from '@prisma/client';
 const prisma = new PrismaClient();
+import { serialize } from '../../utils/serialize.js';
 
 export async function getAllRegions(language = 'ru') {
-  return prisma.region.findMany({
+  const regions = await prisma.region.findMany({
     select: {
       id: true,
       lat: true,
@@ -24,10 +25,11 @@ export async function getAllRegions(language = 'ru') {
       }
     }
   });
+  return serialize(regions);
 }
 
 export async function getCitiesByRegion(regionId, language = 'ru') {
-  return prisma.city.findMany({
+  const cities = await prisma.city.findMany({
     where: { regionId },
     select: {
       id: true,
@@ -39,4 +41,5 @@ export async function getCitiesByRegion(regionId, language = 'ru') {
       }
     }
   });
+  return serialize(cities);
 }

--- a/src/api/notifications/notifications.service.js
+++ b/src/api/notifications/notifications.service.js
@@ -1,13 +1,15 @@
 import { PrismaClient } from '@prisma/client';
 import admin from '../../core/firebase.js';
+import { serialize } from '../../utils/serialize.js';
 const messaging = admin.messaging();
 const prisma = new PrismaClient();
 
 export async function getUserNotifications(userId) {
-  return prisma.notification.findMany({
+  const notifications = await prisma.notification.findMany({
     where: { userId },
     orderBy: { createdAt: 'desc' },
   });
+  return serialize(notifications);
 }
 
 export async function getUnreadCount(userId) {
@@ -17,17 +19,19 @@ export async function getUnreadCount(userId) {
 }
 
 export async function markAsRead(userId, notificationId) {
-  return prisma.notification.updateMany({
+  const result = await prisma.notification.updateMany({
     where: { id: notificationId, userId },
     data: { isRead: true },
   });
+  return serialize(result);
 }
 
 export async function markAllAsRead(userId) {
-  return prisma.notification.updateMany({
+  const result = await prisma.notification.updateMany({
     where: { userId, isRead: false },
     data: { isRead: true },
   });
+  return serialize(result);
 }
 
 export async function sendPushNotification(token, title, body, data = {}) {

--- a/src/api/purchased/purchased.service.js
+++ b/src/api/purchased/purchased.service.js
@@ -1,8 +1,9 @@
 import { PrismaClient } from '@prisma/client';
 const prisma = new PrismaClient();
+import { serialize } from '../../utils/serialize.js';
 
 export async function getByUser(userId) {
-  return prisma.purchasedContact.findMany({
+  const records = await prisma.purchasedContact.findMany({
     where: { userId },
     select: {
       serviceId: true,
@@ -26,4 +27,5 @@ export async function getByUser(userId) {
       }
     }
   });
+  return serialize(records);
 }

--- a/src/api/reviews/reviews.service.js
+++ b/src/api/reviews/reviews.service.js
@@ -1,5 +1,6 @@
 import admin from '../../core/firebase.js';
 import { PrismaClient } from '@prisma/client';
+import { serialize } from '../../utils/serialize.js';
 const prisma = new PrismaClient();
 
 export async function submitReview(userId, data) {
@@ -42,9 +43,7 @@ export async function submitReview(userId, data) {
     });
   }
 
-  return JSON.parse(JSON.stringify({ message: 'Review submitted', review }, (key, value) =>
-    typeof value === 'bigint' ? value.toString() : value
-  ));
+  return serialize({ message: 'Review submitted', review });
 }
 
 export async function getReviewsByService(serviceId) {
@@ -57,7 +56,5 @@ export async function getReviewsByService(serviceId) {
   });
 
   // Корректная сериализация: bigint -> string, Date -> ISO string
-  return JSON.parse(JSON.stringify(reviews, (key, value) =>
-    typeof value === 'bigint' ? value.toString() : value
-  ));
+  return serialize(reviews);
 }

--- a/src/api/services/services.service.js
+++ b/src/api/services/services.service.js
@@ -1,6 +1,7 @@
 import { PrismaClient } from '@prisma/client';
 const prisma = new PrismaClient();
-import { spendFromWallet } from "../wallet/wallet.service.js";
+import { spendFromWallet } from '../wallet/wallet.service.js';
+import { serialize } from '../../utils/serialize.js';
 
 export async function createService(userId, data) {
   const {
@@ -15,11 +16,7 @@ export async function createService(userId, data) {
     }
   });
 
-  return JSON.parse(
-    JSON.stringify(service, (key, value) =>
-      typeof value === 'bigint' ? value.toString() : value
-    )
-  );
+  return serialize(service);
 }
 
 export async function getServiceById(id, userId) {
@@ -45,11 +42,7 @@ export async function getServiceById(id, userId) {
     contact: purchased ? service.user : null
   };
 
-  return JSON.parse(
-    JSON.stringify(result, (key, value) =>
-      typeof value === 'bigint' ? value.toString() : value
-    )
-  );
+  return serialize(result);
 }
 
 export async function getServices(filters = {}) {
@@ -112,15 +105,12 @@ export async function getServices(filters = {}) {
     };
   });
 
-  return JSON.parse(
-    JSON.stringify({
-      total,
-      page: pageNum,
-      limit: take,
-      services: result
-    },
-    (key, value) => typeof value === 'bigint' ? value.toString() : value)
-  );
+  return serialize({
+    total,
+    page: pageNum,
+    limit: take,
+    services: result
+  });
 }
 
 export async function updateService(userId, serviceId, data) {
@@ -138,7 +128,8 @@ export async function updateService(userId, serviceId, data) {
     if (data[field] !== undefined) updateData[field] = data[field];
   }
 
-  return prisma.service.update({ where: { id: serviceId }, data: updateData });
+  const updated = await prisma.service.update({ where: { id: serviceId }, data: updateData });
+  return serialize(updated);
 }
 
 export async function promoteService(userId, serviceId, days) {

--- a/src/api/subcategories/subcategories.service.js
+++ b/src/api/subcategories/subcategories.service.js
@@ -1,8 +1,9 @@
 import { PrismaClient } from '@prisma/client';
 const prisma = new PrismaClient();
+import { serialize } from '../../utils/serialize.js';
 
 export async function getSubcategoriesByCategory(categoryId, language = 'ru') {
-  return prisma.subcategory.findMany({
+  const subcategories = await prisma.subcategory.findMany({
     where: { categoryId },
     select: {
       id: true,
@@ -12,10 +13,11 @@ export async function getSubcategoriesByCategory(categoryId, language = 'ru') {
       }
     }
   });
+  return serialize(subcategories);
 }
 
 export async function createSubcategory({ categoryId, translations }) {
-  return prisma.subcategory.create({
+  const subcategory = await prisma.subcategory.create({
     data: {
       categoryId,
       SubcategoryTranslation: {
@@ -26,12 +28,13 @@ export async function createSubcategory({ categoryId, translations }) {
       }
     }
   });
+  return serialize(subcategory);
 }
 
 export async function updateSubcategory(id, { translations }) {
   await prisma.subcategoryTranslation.deleteMany({ where: { subcategoryId: id } });
 
-  return prisma.subcategory.update({
+  const updated = await prisma.subcategory.update({
     where: { id },
     data: {
       SubcategoryTranslation: {
@@ -42,6 +45,7 @@ export async function updateSubcategory(id, { translations }) {
       }
     }
   });
+  return serialize(updated);
 }
 
 export async function deleteSubcategory(id) {

--- a/src/api/users/users.service.js
+++ b/src/api/users/users.service.js
@@ -1,5 +1,6 @@
 import { PrismaClient } from '@prisma/client';
 const prisma = new PrismaClient();
+import { serialize } from '../../utils/serialize.js';
 
 export async function getUserById(id) {
   const user = await prisma.user.findUnique({
@@ -21,7 +22,7 @@ export async function getUserById(id) {
 
   if (!user) throw new Error('User not found');
 
-  return user;
+  return serialize(user);
 }
 
 export async function updateUser(id, data) {
@@ -66,12 +67,13 @@ export async function updateUser(id, data) {
     }
   });
 
-  return user;
+  return serialize(user);
 }
 
 export async function updatePushToken(userId, pushToken) {
-  return prisma.user.update({
+  const updated = await prisma.user.update({
     where: { id: userId },
     data: { pushToken },
   });
+  return serialize(updated);
 }

--- a/src/api/wallet/wallet.service.js
+++ b/src/api/wallet/wallet.service.js
@@ -1,5 +1,6 @@
 import admin from '../../core/firebase.js';
 import { PrismaClient } from '@prisma/client';
+import { serialize } from '../../utils/serialize.js';
 const prisma = new PrismaClient();
 
 export async function getMyWallet(userId) {
@@ -14,7 +15,7 @@ export async function getMyWallet(userId) {
     });
   }
 
-  return wallet;
+  return serialize(wallet);
 }
 
 export async function topUpWallet(userId, amount) {
@@ -48,7 +49,7 @@ export async function topUpWallet(userId, amount) {
     });
   }
 
-  return wallet;
+  return serialize(wallet);
 }
 
 export async function spendFromWallet(userId, amount) {
@@ -57,7 +58,7 @@ export async function spendFromWallet(userId, amount) {
   const wallet = await getMyWallet(userId);
   if (wallet.balance < amount) throw new Error('Insufficient balance');
 
-  return await prisma.wallet.update({
+  const updated = await prisma.wallet.update({
     where: { id: wallet.id },
     data: {
       balance: { decrement: amount },
@@ -67,4 +68,5 @@ export async function spendFromWallet(userId, amount) {
     },
     include: { transactions: true }
   });
+  return serialize(updated);
 }

--- a/src/utils/serialize.js
+++ b/src/utils/serialize.js
@@ -1,0 +1,7 @@
+export function serialize(data) {
+  return JSON.parse(
+    JSON.stringify(data, (_, value) =>
+      typeof value === 'bigint' ? value.toString() : value
+    )
+  );
+}


### PR DESCRIPTION
## Summary
- add shared `serialize` util for converting `BigInt` to string
- use `serialize` for all service responses so JSON.stringify works

## Testing
- `npm run build:openapi` *(fails: Cannot find package 'yaml')*


------
https://chatgpt.com/codex/tasks/task_e_683f02772c54832491552b299ba439ff