### PR TITLE
Add promotion tariffs and expiry system

### DIFF
--- a/src/api/jobs/jobs.controller.js
+++ b/src/api/jobs/jobs.controller.js
@@ -32,8 +32,8 @@ export async function getJobById(req, res) {
 
 export async function promoteJob(req, res) {
   try {
-    const { days } = req.body;
-    const result = await jobService.promoteJob(req.user.userId, req.params.id, days);
+    const { tariffId } = req.body;
+    const result = await jobService.promoteJob(req.user.userId, req.params.id, tariffId);
     res.json(result);
   } catch (error) {
     console.error('🔥 Promote Job error:', error);

--- a/src/api/purchased/purchased.controller.js
+++ b/src/api/purchased/purchased.controller.js
@@ -9,3 +9,33 @@ export async function getMyPurchasedContacts(req, res) {
     res.status(500).json({ error: 'Failed to fetch purchased contacts' });
   }
 }
+
+export async function getTariffs(req, res) {
+  try {
+    const tariffs = await purchasedService.getTariffs();
+    res.json(tariffs);
+  } catch (error) {
+    console.error('🔥 Get Tariffs error:', error);
+    res.status(500).json({ error: 'Failed to fetch tariffs' });
+  }
+}
+
+export async function createTariff(req, res) {
+  try {
+    const tariff = await purchasedService.createTariff(req.body);
+    res.json(tariff);
+  } catch (error) {
+    console.error('🔥 Create Tariff error:', error);
+    res.status(500).json({ error: 'Failed to create tariff' });
+  }
+}
+
+export async function updateTariff(req, res) {
+  try {
+    const tariff = await purchasedService.updateTariff(req.params.id, req.body);
+    res.json(tariff);
+  } catch (error) {
+    console.error('🔥 Update Tariff error:', error);
+    res.status(500).json({ error: 'Failed to update tariff' });
+  }
+}

--- a/src/api/purchased/purchased.routes.js
+++ b/src/api/purchased/purchased.routes.js
@@ -1,10 +1,15 @@
 import { Router } from 'express';
 import * as purchasedController from './purchased.controller.js';
 import { authMiddleware } from '../../middleware/authMiddleware.js';
+import { adminMiddleware } from '../../middleware/adminMiddleware.js';
 
 const router = Router();
 
 // Получить список купленных контактов текущего пользователя
 router.get('/', authMiddleware, purchasedController.getMyPurchasedContacts);
+
+router.get('/tariffs', authMiddleware, purchasedController.getTariffs);
+router.post('/tariffs', adminMiddleware, purchasedController.createTariff);
+router.patch('/tariffs/:id', adminMiddleware, purchasedController.updateTariff);
 
 export default router;

--- a/src/api/purchased/purchased.service.js
+++ b/src/api/purchased/purchased.service.js
@@ -18,3 +18,15 @@ export async function getByUser(userId) {
     }
   });
 }
+
+export function getTariffs() {
+  return prisma.tariff.findMany({ orderBy: { order: 'asc' } });
+}
+
+export function createTariff(data) {
+  return prisma.tariff.create({ data });
+}
+
+export function updateTariff(id, data) {
+  return prisma.tariff.update({ where: { id: parseInt(id) }, data });
+}

--- a/src/api/services/services.controller.js
+++ b/src/api/services/services.controller.js
@@ -42,8 +42,8 @@ export async function updateService(req, res) {
 
 export async function promoteService(req, res) {
   try {
-    const { days } = req.body;
-    const result = await serviceService.promoteService(req.user.userId, req.params.id, days);
+    const { tariffId } = req.body;
+    const result = await serviceService.promoteService(req.user.userId, req.params.id, tariffId);
     res.json(result);
   } catch (error) {
     console.error('🔥 Promote Service error:', error);

--- a/src/core/prisma/schema.prisma
+++ b/src/core/prisma/schema.prisma
@@ -155,6 +155,7 @@ model Service {
 
   images String[] // Массив URL картинок
   videos String[] // Массив URL видео
+  expiresAt     DateTime
 
   userId        String
   regionId      String?
@@ -178,6 +179,7 @@ model Service {
   @@index([categoryId])
   @@index([subcategoryId])
   @@index([promotedUntil])
+  @@index([expiresAt])
 }
 
 model Job {
@@ -192,6 +194,7 @@ model Job {
 
   images String[] // Массив URL картинок
   videos String[] // Массив URL видео
+  expiresAt     DateTime
 
   userId   String
   regionId String?
@@ -206,6 +209,7 @@ model Job {
   @@index([cityId])
   @@index([userId])
   @@index([promotedUntil])
+  @@index([expiresAt])
 }
 
 model PurchasedContact {
@@ -315,4 +319,13 @@ model Notification {
 
   userId String
   user   User   @relation(fields: [userId], references: [id])
+}
+
+model Tariff {
+  id          Int    @id @default(autoincrement())
+  name        String
+  price       Int
+  promoDays   Int
+  extraDays   Int
+  order       Int    @default(0)
 }

--- a/src/docs/modules/jobs.yaml
+++ b/src/docs/modules/jobs.yaml
@@ -100,7 +100,7 @@
     tags:
       - jobs
     summary: Поднять задание в топ
-    description: Платное продвижение задания на 3 или 7 дней
+    description: Продвижение задания по выбранному тарифу
     security:
       - bearerAuth: []
     parameters:
@@ -116,11 +116,10 @@
           schema:
             type: object
             properties:
-              days:
+              tariffId:
                 type: integer
-                enum: [3, 7]
             required:
-              - days
+              - tariffId
     responses:
       '200':
         description: Задание продвинуто

--- a/src/docs/modules/purchased.yaml
+++ b/src/docs/modules/purchased.yaml
@@ -13,3 +13,94 @@
         description: Неавторизованный доступ
       '500':
         description: Ошибка сервера
+
+/purchased/tariffs:
+  get:
+    tags:
+      - purchased
+    summary: Список тарифов на продвижение
+    description: Возвращает доступные тарифы
+    security:
+      - bearerAuth: []
+    responses:
+      '200':
+        description: Список тарифов
+      '401':
+        description: Неавторизованный доступ
+      '500':
+        description: Ошибка сервера
+  post:
+    tags:
+      - purchased
+    summary: Создать тариф
+    description: Добавляет новый тариф (только для администраторов)
+    security:
+      - adminBearerAuth: []
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              name:
+                type: string
+              price:
+                type: integer
+              promoDays:
+                type: integer
+              extraDays:
+                type: integer
+              order:
+                type: integer
+            required:
+              - name
+              - price
+              - promoDays
+              - extraDays
+    responses:
+      '200':
+        description: Тариф создан
+      '401':
+        description: Неавторизованный доступ
+      '500':
+        description: Ошибка сервера
+
+/purchased/tariffs/{id}:
+  patch:
+    tags:
+      - purchased
+    summary: Обновить тариф
+    description: Редактирование существующего тарифа (только для администраторов)
+    security:
+      - adminBearerAuth: []
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              name:
+                type: string
+              price:
+                type: integer
+              promoDays:
+                type: integer
+              extraDays:
+                type: integer
+              order:
+                type: integer
+    responses:
+      '200':
+        description: Тариф обновлён
+      '401':
+        description: Неавторизованный доступ
+      '500':
+        description: Ошибка сервера

--- a/src/docs/modules/services.yaml
+++ b/src/docs/modules/services.yaml
@@ -92,7 +92,7 @@
     tags:
       - services
     summary: Поднять услугу в топ
-    description: Платное продвижение услуги на 3 или 7 дней
+    description: Продвижение услуги по выбранному тарифу
     security:
       - BearerAuth: []
     parameters:
@@ -108,10 +108,10 @@
           schema:
             type: object
             properties:
-              days:
+              tariffId:
                 type: integer
             required:
-              - days
+              - tariffId
     responses:
       '200':
         description: Услуга продвинута


### PR DESCRIPTION
## Summary
- support expiration for services and jobs
- add Tariff model for flexible promotion pricing
- expose tariff management routes
- filter lists by expiry and use tariffs when promoting
- document new tariff endpoints and promotion schema

## Testing
- `node --check src/api/services/services.service.js`
- `node --check src/api/jobs/jobs.service.js`
- `node --check src/api/purchased/purchased.controller.js`
- `node --check src/api/purchased/purchased.routes.js`
- `node --check src/api/purchased/purchased.service.js`
- `node --check src/api/jobs/jobs.controller.js`
- `node --check src/api/services/services.controller.js`
- `npm run build:openapi` *(fails: Cannot find package 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_684eaebe654c8324b9868f2e07ae55af